### PR TITLE
Update SerialCommands.cpp

### DIFF
--- a/src/SerialCommands.cpp
+++ b/src/SerialCommands.cpp
@@ -89,6 +89,7 @@ SERIAL_COMMANDS_ERRORS SerialCommands::ReadSerial()
 #ifdef SERIAL_COMMANDS_DEBUG			
 			Serial.println("Buffer full");
 #endif
+			ClearBuffer();
 			return SERIAL_COMMANDS_ERROR_BUFFER_FULL;
 		}
 


### PR DESCRIPTION
clear buffer if catch buffer full.

if connected other device to serial, maybe send trash on booting
like:

```
Read: bufLen=31 bufPos=0 termPos=0 ch=[�]
Read: bufLen=31 bufPos=1 termPos=0 ch=[�]
Read: bufLen=31 bufPos=2 termPos=0 ch=[%]
Read: bufLen=31 bufPos=3 termPos=0 ch=[�]
Read: bufLen=31 bufPos=4 termPos=0 ch=[�]
Read: bufLen=31 bufPos=5 termPos=0 ch=#3
Read: bufLen=31 bufPos=6 termPos=0 ch=[�]
Read: bufLen=31 bufPos=7 termPos=0 ch=[�]
Read: bufLen=31 bufPos=8 termPos=0 ch=#24
Read: bufLen=31 bufPos=9 termPos=0 ch=[�]
Read: bufLen=31 bufPos=10 termPos=0 ch=[�]
Read: bufLen=31 bufPos=11 termPos=0 ch=#31
Read: bufLen=31 bufPos=12 termPos=0 ch=[�]
Read: bufLen=31 bufPos=13 termPos=0 ch=[�]
Read: bufLen=31 bufPos=14 termPos=0 ch=[ ]
Read: bufLen=31 bufPos=15 termPos=0 ch=[�]
Read: bufLen=31 bufPos=16 termPos=0 ch=[�]
Read: bufLen=31 bufPos=17 termPos=0 ch=[!]
Read: bufLen=31 bufPos=18 termPos=0 ch=[�]
Read: bufLen=31 bufPos=19 termPos=0 ch=[�]
Read: bufLen=31 bufPos=20 termPos=0 ch=["]
Read: bufLen=31 bufPos=21 termPos=0 ch=[�]
Read: bufLen=31 bufPos=22 termPos=0 ch=[�]
Read: bufLen=31 bufPos=23 termPos=0 ch=[']
Read: bufLen=31 bufPos=24 termPos=0 ch=[�]
Read: bufLen=31 bufPos=25 termPos=0 ch=[�]
Read: bufLen=31 bufPos=26 termPos=0 ch=#5
Read: bufLen=31 bufPos=27 termPos=0 ch=[�]
Read: bufLen=31 bufPos=28 termPos=0 ch=[�]
Read: bufLen=31 bufPos=29 termPos=0 ch=[#]
Read: bufLen=31 bufPos=30 termPos=0 ch=[s]
Read: bufLen=31 bufPos=31 termPos=0 ch=[t]
Buffer full
```

and next time trying send command to this serial i got 

```
Read: bufLen=31 bufPos=31 termPos=0 ch=[s]
Buffer full
Read: bufLen=31 bufPos=31 termPos=0 ch=[t]
Buffer full
Read: bufLen=31 bufPos=31 termPos=0 ch=[a]
Buffer full
Read: bufLen=31 bufPos=31 termPos=0 ch=[t]
Buffer full
Read: bufLen=31 bufPos=31 termPos=0 ch=[u]
Buffer full
Read: bufLen=31 bufPos=31 termPos=0 ch=[s]
Buffer full
Read: bufLen=31 bufPos=31 termPos=0 ch=#13
Buffer full
Read: bufLen=31 bufPos=31 termPos=0 ch=#10
Buffer full
```

this pull request fix this situation 